### PR TITLE
fix: update JSON ignore patterns to match files in subdirectories

### DIFF
--- a/packages/eslint-config-complete/src/base/base-complete.js
+++ b/packages/eslint-config-complete/src/base/base-complete.js
@@ -59,7 +59,7 @@ export const baseComplete = defineConfig(
     // Rules that require type information will throw an error on ".json" files. (This is needed
     // when using `eslint-plugin-package-json`. Even though this config does not currently use the
     // plugin, we include it here defensively.)
-    ignores: ["*.json", "*.jsonc"],
+    ignores: ["**/*.json", "**/*.jsonc"],
   },
 
   {

--- a/packages/eslint-config-complete/src/base/base-typescript-eslint.js
+++ b/packages/eslint-config-complete/src/base/base-typescript-eslint.js
@@ -501,7 +501,7 @@ export const baseTypeScriptESLint = defineConfig(
     // Rules that require type information will throw an error on ".json" files. (This is needed
     // when using `eslint-plugin-package-json`. Even though this config does not currently use the
     // plugin, we include it here defensively.)
-    ignores: ["*.json", "*.jsonc"],
+    ignores: ["**/*.json", "**/*.jsonc"],
   },
 
   // Enable linting on TypeScript file extensions.


### PR DESCRIPTION
# Problem
The current ignore patterns use `*.json` and `*.jsonc`, which only match JSON files in the root directory. This causes TypeScript ESLint rules to attempt linting JSON files in subdirectories, resulting in parser errors.

# Solution
Updated the patterns to `**/*.json` and `**/*.jsonc` to properly match JSON files in all subdirectories.

# Files Changed
- `packages/eslint-config-complete/src/base/base-complete.js`
- `packages/eslint-config-complete/src/base/base-typescript-eslint.js`

# Testing
Verified that JSON files in subdirectories are now properly ignored and don't cause TypeScript parser errors.